### PR TITLE
ECO-946 updates needed for the multi-sig tutorial

### DIFF
--- a/client/src/keys-manager.js
+++ b/client/src/keys-manager.js
@@ -10,9 +10,9 @@ const utils = require('./utils');
     // 1. Set mainAccount's weight to 3.
     // 2. Set Keys Management Threshold to 3.
     // 3. Set Deploy Threshold to 2.
-    // 4. Add first new key with weight 1.
-    // 5. Add second new key with weight 1.
-    // 6. Make a transfer from mainAccount using only both accounts.
+    // 4. Add first new key with weight 1 (first account).
+    // 5. Add second new key with weight 1 (second account).
+    // 6. Make a transfer from mainAccount using the new accounts.
     // 7. Remove first account.
     // 8. Remove second account.
 
@@ -49,21 +49,21 @@ const utils = require('./utils');
     await utils.sendDeploy(deploy, [mainAccount]);
     await utils.printAccount(mainAccount);
     
-    // 4. Add first new key with weight 1.
+    // 4. Add first new key with weight 1 (first account).
     console.log("\n4. Add first new key with weight 1.\n");
     deploy = utils.keys.setKeyWeightDeploy(mainAccount, firstAccount, 1);
     await utils.sendDeploy(deploy, [mainAccount]);
     await utils.printAccount(mainAccount);
     
-    // 5. Add second new key with weight 1.
+    // 5. Add second new key with weight 1 (second account).
     console.log("\n5. Add second new key with weight 1.\n");
     deploy = utils.keys.setKeyWeightDeploy(mainAccount, secondAccount, 1);
     await utils.sendDeploy(deploy, [mainAccount]);
     await utils.printAccount(mainAccount);
     
-    // 6. Make a transfer from faucet using only both accounts.
-    console.log("\n6. Make a transfer from faucet using only both accounts.\n");
-    deploy = utils.transferDeploy(mainAccount, firstAccount, 1);
+    // 6. Make a transfer from faucet using the new accounts.
+    console.log("\n6. Make a transfer from faucet using the new accounts.\n");
+    deploy = utils.transferDeploy(mainAccount, firstAccount, 2500000000);
     await utils.sendDeploy(deploy, [firstAccount, secondAccount]);
     await utils.printAccount(mainAccount);
     

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -8,8 +8,8 @@ let wasmPath = '../contract/target/wasm32-unknown-unknown/release/keys-manager.w
 let networkName = 'casper-net-1';
 
 
-// Load the faucet key.
-let baseKeyPath = "/home/ziel/workspace/casperlabs/casper-node/utils/nctl/assets/net-1/faucet/";
+// Load the faucet key. Replace <ENTER_YOUR_PATH> with the directory where your casper-node repository resides.
+let baseKeyPath = "<ENTER_YOUR_PATH>/casper-node/utils/nctl/assets/net-1/faucet/";
 let privateKeyPath = baseKeyPath + "secret_key.pem";
 let publicKeyPath = baseKeyPath + "public_key.pem";
 let faucetAccount = Keys.Ed25519.parseKeyFiles(publicKeyPath, privateKeyPath);


### PR DESCRIPTION
Summary of changes:
1. To run the keys-manager.js client, we need to update the deploy transfer amount from 1 to 2500000000. Otherwise, step 6 will throw and error.
`deploy = utils.transferDeploy(mainAccount, firstAccount, 2500000000);`
2. I updated some comments in the keys-manager.js file. This will help with the corresponding tutorial.
3. In utils.js, I made the _casper-node_ path more general, prompting users to enter their path.
