### PR TITLE
Update Key manager contract to use `wee_alloc`

### DIFF
--- a/contract/.rustfmt.toml
+++ b/contract/.rustfmt.toml
@@ -1,0 +1,4 @@
+wrap_comments = true
+comment_width = 100
+imports_granularity = "Crate"
+edition = "2021"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["edition2021"]
 [package]
 name = "keys-manager"
 version = "0.2.0"
-authors = ["Maciej Zielinski <maciek.s.zielinski@gmail.com>"]
+authors = ["Maciej Zielinski <maciek.s.zielinski@gmail.com>", "Matthew Doty <matthew.wampler.doty@gmail.com>"]
 edition = "2021"
 
 [dependencies]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -16,8 +16,9 @@ doctest = false
 test = false
 
 [features]
-default = ["std"]
-std = ["casper-contract/std", "casper-types/std"]
+default = ["wee-alloc"]
+wee-alloc = ["casper-contract/no-std-helpers"]
 
 [profile.release]
+codegen-units = 1
 lto = true

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -1,8 +1,10 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "keys-manager"
 version = "0.2.0"
 authors = ["Maciej Zielinski <maciek.s.zielinski@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 casper-contract = { version = "1.4.0", default-features = false }

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -1,4 +1,9 @@
 #![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 use casper_contract::{
     contract_api::{account, runtime, storage},


### PR DESCRIPTION
The standard allocator has a larger footprint than [`wee_alloc`][1].

Using `wee_alloc` in the reference smart contract encourages smart contract authors to write smaller deploys.

[1]: https://github.com/rustwasm/wee_alloc